### PR TITLE
Update http dependency to ^1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ api_key.dart
 pubspec.lock
 doc/api/
 .idea/
+.DS_Store

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://purefun.dev
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: ^0.13.5
+  http: ^1.0.0
 dev_dependencies:
   test : ^1.17.3


### PR DESCRIPTION
I suggest updating the `http` dependency so that this package doesn't cause conflicts with others.

Also, an unrelated side note: maybe you should 'unfork' this repo from the parent since it has been stale for like 4 years and the owner seems to be AFK, and it's not possible to make issues on your fork etc. See: https://ralphjsmit.com/unfork-github-repo