### PR TITLE
Update http version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://purefun.dev
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: ^0.13.5
+  http: ^1.0.0
 dev_dependencies:
   test : ^1.17.3


### PR DESCRIPTION
The Flutter ecosystem is moving forward with `http` version `1.0.0`, and I had to update this dep just to use `flutter_pexels_api`.